### PR TITLE
Listen to the connection status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_install:
   - sudo docker build -t rcldocker .
 
 script:
-  - sudo docker run -v $(pwd):/root/ros2bridge_suite-experiment --rm rcldocker bash -i -c 'cd /root/ros2bridge_suite-experiment && npm install --unsafe-perm && npm run lint'
+  - sudo docker run -v $(pwd):/root/ros2-web-bridge --rm rcldocker bash -i -c 'cd /root/ros2-web-bridge && npm install --unsafe-perm && npm run lint'

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -15,7 +15,9 @@
 'use strict';
 
 const rclnodejs = require('rclnodejs');
-const debug = require('debug')('ros2bridge:Bridge');
+const debug = require('debug')('ros2-web-bridge:Bridge');
+const EventEmitter = require('events');
+const uuidv4 = require('uuid/v4');
 
 class MessageParser {
   constructor() {
@@ -61,17 +63,47 @@ class MessageParser {
   }
 }
 
-class Bridge {
+class Bridge extends EventEmitter {
   constructor(nodeManager, ws) {
+    super();
     this._nodeManager = nodeManager;
     this._ws = ws;
     this._parser = new MessageParser();
     this._bridgeId = this._generateRandomId();
     this._servicesResponse = new Map();
+    this._closed = false;
+
+    this._registerConnectionEvent(ws);
+  }
+
+  _registerConnectionEvent(ws) {
+    ws.on('message', (message) => {
+      this._receiveMessage(message);
+    });
+
+    ws.on('close', () => {
+      this.close();
+      this.emit('close', this._bridgeId);
+      debug('Web socket connection closed');
+    });
+
+    ws.on('error', (error) => {
+      error.bridge = this;
+      this.emit('error', error);
+      debug(`Web socket connection error: ${error}`);
+    });
+  }
+
+  close() {
+    if (!this._closed) {
+      this._nodeManager.cleanResourceByBridgeId(this._bridgeId);
+      this._servicesResponse.clear();
+      this._closed = true;
+    }
   }
 
   _generateRandomId() {
-    return Math.floor(Math.random() * Number.MAX_VALUE).toString();
+    return uuidv4();
   }
 
   _exractMessageType(type) {
@@ -84,11 +116,7 @@ class Bridge {
     return splitted[0] + '/srv/' + splitted[1];
   }
 
-  get bridgeId() {
-    return this._bridgeId;
-  }
-
-  receiveMessage(message) {
+  _receiveMessage(message) {
     const command = this._parser.process(message);
     if (!command) return;
 
@@ -96,102 +124,114 @@ class Bridge {
     this.executeCommand(command);
   }
 
+  get bridgeId() {
+    return this._bridgeId;
+  }
+
+  get closed() {
+    return this._closed;
+  }
+
   executeCommand(command) {
-    if (command.op === 'advertise') {
-      debug(`advertise a topic: ${command.topic}`);
-      this._nodeManager.createPublisher(this._exractMessageType(command.type), command.topic);
-    }
+    try {
+      if (command.op === 'advertise') {
+        debug(`advertise a topic: ${command.topic}`);
+        this._nodeManager.createPublisher(this._exractMessageType(command.type), command.topic, this._bridgeId);
+      }
 
-    if (command.op === 'unadvertise') {
-      debug(`unadvertise a topic: ${command.topic}`);
-      this._nodeManager.destroyPubliser(command.topic);
-    }
+      if (command.op === 'unadvertise') {
+        debug(`unadvertise a topic: ${command.topic}`);
+        this._nodeManager.destroyPublisher(command.topic, this._bridgeId);
+      }
 
-    if (command.op === 'publish') {
-      debug(`Publish a topic named ${command.topic} with ${JSON.stringify(command.msg)}`);
+      if (command.op === 'publish') {
+        debug(`Publish a topic named ${command.topic} with ${JSON.stringify(command.msg)}`);
 
-      let publisher = this._nodeManager.getPublishByTopic(command.topic);
-      if (publisher) {
-        publisher.publish(command.msg);
+        let publisher = this._nodeManager.getPublisherByTopic(command.topic, this._bridgeId);
+        if (publisher) {
+          publisher.publish(command.msg);
+        }
+      }
+
+      if (command.op === 'subscribe') {
+        debug(`subscribe a topic named ${command.topic}`);
+
+        this._nodeManager.createSubscription(this._exractMessageType(command.type),
+                                             command.topic,
+                                             this._bridgeId,
+                                             this._sendSubscriptionResponse.bind(this));
+      }
+
+      if (command.op === 'unsubscribe') {
+        debug(`unsubscribe a topic named ${command.topic}`);
+        this._nodeManager.destroySubscription(command.topic, this._bridgeId);
+      }
+
+      if (command.op === 'call_service') {
+        let serviceName = command.service;
+        let client =
+          this._nodeManager.createClient(this._exractServiceType(command.args.type), serviceName, this._bridgeId);
+
+        if (client) {
+          client.sendRequest(command.args.request, (response) => {
+            let serviceResponse =
+              {op: 'service_response', service: command.service, values: response, id: command.id, result: true};
+
+            this._ws.send(JSON.stringify(serviceResponse));
+          });
+        }
+      }
+
+      if (command.op === 'advertise_service') {
+        let serviceName = command.service;
+        let service = this._nodeManager.createService(
+          this._exractServiceType(command.type),
+          serviceName, this._bridgeId,
+          (request, response) => {
+            let id = this._generateRandomId();
+            let serviceRequest = {op: 'call_service', service: command.service, args: request, id: id};
+            this._servicesResponse.set(id, response);
+            this._ws.send(JSON.stringify(serviceRequest));
+          });
+      }
+
+      if (command.op === 'service_response') {
+        let serviceName = command.service;
+        let id = command.id;
+        let response = this._servicesResponse.get(id);
+        if (response) {
+          response.send(command.values);
+          this._servicesResponse.delete(id);
+        }
+      }
+
+      if (command.op === 'unadvertise_service') {
+        this._nodeManager.destroyService(command.service, bridgeId);
       }
     }
-
-    if (command.op === 'subscribe') {
-      debug(`subscribe a topic named ${command.topic}`);
-
-      this._nodeManager.createSubscription(
-        this._exractMessageType(command.type), command.topic, this._bridgeId, this.sendSubscriptionResponse.bind(this));
+    catch (error) {
+      error.id = command.id;
+      error.op = command.op;
+      this._sendBackOperationError(error);
     }
-
-    if (command.op === 'unsubscribe') {
-      debug(`unsubscribe a topic named ${command.topic}`);
-      this._nodeManager.destroySubscription(command.topic);
-    }
-
-    if (command.op === 'call_service') {
-      let serviceName = command.service;
-      let client = this._nodeManager.createClient(this._exractServiceType(command.args.type), serviceName);
-
-      if (client) {
-        client.sendRequest(command.args.request, (response) => {
-          let serviceResponse =
-            {op: 'service_response', service: command.service, values: response, id: command.id, result: true};
-          
-          this._ws.send(JSON.stringify(serviceResponse));
-        });
-      }
-    }
-
-    if (command.op === 'advertise_service') {
-      let serviceName = command.service;
-      let service = this._nodeManager.createService(
-        this._exractServiceType(command.type),
-        serviceName, this._bridgeId,
-        (request, response) => {
-          let id = this._generateRandomId();
-          let serviceRequest = {op: 'call_service', service: command.service, args: request, id: id};
-          this._servicesResponse.set(id, response);
-
-          this._ws.send(JSON.stringify(serviceRequest));
-        });
-    }
-
-    if (command.op === 'service_response') {
-      let serviceName = command.service;
-      let id = command.id;
-      let response = this._servicesResponse.get(id);
-      if (response) {
-        response.send(command.values);
-        this._servicesResponse.delete(id);
-      }
-    }
-
-    if (command.op === 'unadvertise_service') {
-      this._nodeManager.destroyService(command.service);
-    }
-
-
   }
 
-  clean() {
-    // TODO: destroy the resource when the socket connection is closed.
-  }
-
-  sendSubscriptionResponse(topicName, message) {
-    debug(`Send subscription response: ${message}`);
+  _sendSubscriptionResponse(topicName, message) {
+    debug('Send message to subscription.');
     let response = {op: 'publish', topic: topicName, msg: message};
     this._ws.send(JSON.stringify(response));
   }
 
-  sendBackCommandStatus(id, error) {
-    let command;
-    if (!error) {
-      command = {op: 'set_level', id: id, level: 'none'};
-    } else {
-      command = {op: 'set_level', id: id, level: 'error'};
+  _sendBackOperationError(error) {
+    if (error) {
+      let command = {op: 'set_level', id: error.id, level: 'error'};
+      debug(`Error: ${error} happened when executing command ${error.op}`);
+      this._ws.send(JSON.stringify(command));
     }
-    debug(`Status message: ${JSON.stringify(command)}`);
-    this._ws.send(JSON.stringify(command));
+  }
+
+  get ws() {
+    return this._ws;
   }
 }
 

--- a/lib/node_manager.js
+++ b/lib/node_manager.js
@@ -15,13 +15,15 @@
 'use strict';
 
 const rclnodejs = require('rclnodejs');
-const debug = require('debug')('ros2bridge:NodeManager');
+const debug = require('debug')('ros2-web-bridge:NodeManager');
 
 class HandleWithCallbacks {
   constructor(handle) {
-    this._handle = handle;
-    this._callbacks = new Map();
-    this._count = 1;
+    if (handle) {
+      this._handle = handle;
+      this._callbacks = new Map();
+      this._count = 1;
+    }
   }
 
   get handle() {
@@ -36,12 +38,18 @@ class HandleWithCallbacks {
     this._callbacks.delete(id);
   }
 
+  hasCallbackForId(id) {
+    return this._callbacks.has(id);
+  }
+
   get callbacks() {
     return Array.from(this._callbacks.values());
   }
 
   release() {
-    this._count--;
+    if (this._count > 0) {
+      this._count--;
+    }
   }
 
   retain() {
@@ -62,124 +70,196 @@ class NodeManager {
     this._services = new Map();
   }
 
-  createPublisher(messageType, topicName) {
-    let handleWithCallbacks = this._publishers.get(topicName);
-    if (!handleWithCallbacks) {
-      let publisher = this._node.createPublisher(messageType, topicName);
-      handleWithCallbacks = new HandleWithCallbacks(publisher);
-      this._publishers.set(topicName, handleWithCallbacks);
-      debug(`Publisher has been created, and the topic is ${topicName}.`);
-    } else {
-      handleWithCallbacks.retain();
+  createPublisher(messageType, topicName, bridgeId) {
+    let map = this._publishers.get(bridgeId);
+    if (!map) {
+      map = new Map();
+      this._publishers.set(bridgeId, map);
     }
 
-    return handleWithCallbacks.handle;
+    let publisherHandle = map.get(topicName);
+    if (!publisherHandle) {
+      publisherHandle = new HandleWithCallbacks(this._node.createPublisher(messageType, topicName));
+      map.set(topicName, publisherHandle);
+      debug(`Publisher has been created, and the topic is ${topicName}.`);
+    } else {
+      publisherHandle.retain();
+    }
+    return publisherHandle.handle;
   }
 
   createSubscription(messageType, topicName, bridgeId, callback) {
-    let handleWithCallbacks = this._subscriptions.get(topicName);
-    if (!handleWithCallbacks) {
+    let subscriptionHandle = this._subscriptions.get(topicName);
+    if (!subscriptionHandle) {
       let subscription = this._node.createSubscription(messageType, topicName, (message) => {
         this._subscriptions.get(topicName).callbacks.forEach(callback => {
           callback(topicName, message);
         });
       });
 
+      subscriptionHandle = new HandleWithCallbacks(subscription);
+      subscriptionHandle.addCallback(bridgeId, callback);
+      this._subscriptions.set(topicName, subscriptionHandle);
       debug(`Subscription has been created, and the topic is ${topicName}.`);
-      handleWithCallbacks = new HandleWithCallbacks(subscription);
-      handleWithCallbacks.addCallback(bridgeId, callback);
-      this._subscriptions.set(topicName, handleWithCallbacks);
-    } else {
-      handleWithCallbacks.retain();
-      handleWithCallbacks.addCallback(bridgeId, callback);
+      return subscriptionHandle.handle;
     }
 
-    return handleWithCallbacks.handle;
+    if (!subscriptionHandle.hasCallbackForId(bridgeId)) {
+      subscriptionHandle.addCallback(bridgeId, callback);
+      subscriptionHandle.retain();
+      return subscriptionHandle.handle;
+    }
   }
 
-  createClient(serviceType, serviceName) {
-    let client = this._clients.get(serviceName);
-    if (!client) {
-      client = this._node.createClient(serviceType, serviceName);
-      this._clients.set(serviceName, client);
+  createClient(serviceType, serviceName, bridgeId) {
+    let map = this._clients.get(bridgeId);
+    if (!map) {
+      map = new Map();
+      this._clients.set(bridgeId, map);
     }
-    return client;
+
+    let clientHandle = map.get(serviceName);
+    if (!clientHandle) {
+      clientHandle = new HandleWithCallbacks(this._node.createClient(serviceType, serviceName));
+      map.set(serviceName, clientHandle);
+      debug(`Client has been created, and the service name is ${serviceName}.`);
+    } else {
+      clientHandle.retain();
+    }
+    return clientHandle.handle;
   }
 
   createService(serviceType, serviceName, bridgeId, callback) {
-    let service = this._services.get(serviceName);
-    if (!service) {
-      service = this._node.createService(serviceType, serviceName, (request, response) => {
-        callback(request, response);
-      });
-
-      this._services.set(serviceName, service);
-      return service;
+    let map = this._services.get(bridgeId);
+    if (!map) {
+      map = new Map();
+      this._services.set(bridgeId, map);
     }
 
-    throw Error(`There is already service named ${serviceName}`);
+    if (!map.has(serviceName)) {
+      let service = this._node.createService(serviceType, serviceName, (request, response) => {
+        callback(request, response);
+      });
+      map.set(serviceName, service);
+      return service;
+    }
   }
 
-  getPublishByTopic(topicName) {
-    if (this._publishers.has(topicName)) {
-      return this._publishers.get(topicName).handle;
+  getPublisherByTopic(topicName, bridgeId) {
+    let map = this._publishers.get(bridgeId);
+    if (map) {
+      if (map.has(topicName)) {
+        return map.get(topicName).handle;
+      }
     }
   }
 
   getSubscriptionByTopic(topicName) {
-    if (this._subscriptions.has(topicName)) {
-      return this._subscriptions.get(topicName).handle;
+    if (this._subscripions.has(topicName)) {
+      return this._subscripions.get(topicName);
     }
   }
 
-  destroyPublisher(topicName) {
-    let handleWithCallbacks = this._publishers.get(topicName);
-    if (handleWithCallbacks) {
-      handleWithCallbacks.release();
-      if (handleWithCallbacks.count === 0) {
-        this._node.destroyPublisher(handleWithCallbacks.handle);
-        debug(`Publisher has been destroyed, and the topic is ${topicName}.`);
-        this._publishers.delete(topicName);
+  destroyPublisher(topicName, bridgeId) {
+    let map = this._publishers.get(bridgeId);
+    if (map) {
+      let publisherHandle = map.get(topicName);
+      if (publisherHandle) {
+        publisherHandle.release();
+        if (handle.count === 0) {
+          this._node.destroyPublisher(publisherHandle.handle);
+          map.delete(topicName);
+          debug(`Publisher is destroyed, and the topic name is ${topicName}.`);
+        }
       }
     }
   }
 
   destroySubscription(topicName, bridgeId) {
-    let handleWithCallbacks = this._subscriptions.get(topicName);
-    if (handleWithCallbacks) {
-      handleWithCallbacks.release();
-      handleWithCallbacks.removeCallback(bridgeId);
+    let subscriptionHandle = this._subscriptions.get(topicName);
+    if (subscriptionHandle) {
+      if (subscriptionHandle.hasCallbackForId(bridgeId)) {
+        subscriptionHandle.removeCallback(bridgeId);
+        subscriptionHandle.release();
+      }
 
-      if (handleWithCallbacks.count === 0) {
-        this._node.destroySubscription(handleWithCallbacks.handle);
-        debug(`Subscription has been destroyed, and the topic is ${topicName}.`);
-        this._subscriptions.delete(topicName);
+      if (subscriptionHandle.count === 0) {
+        this._node.destroySubscription(subscriptionHandle.handle);
+        debug(`Subscription is destroyed, and the topic name is ${topicName}.`);
       }
     }
   }
 
-  destroyService(serviceName) {
-    let service = this._services.get(serviceName);
-    if (service) {
-      this._node.destroyService(service);
+  destroyClient(serviceName, bridgeId) {
+    let map = this._clients.get(bridgeId);
+    if (map) {
+      let clientHandle = map.get(serviceName);
+      if (clientHandle) {
+        clientHandle.release();
+        if (clientHandle.count === 0) {
+          this._node.destroyClient(clientHandle.handle);
+          map.delete(serviceName);
+          debug(`Client is destroyed, and the service name is ${serviceName}.`);
+        }
+      }
     }
   }
 
-  start() {
-    rclnodejs.spin(this._node);
+  destroyService(serviceName, bridgeId) {
+    let map = this._services.get(bridgeId);
+    if (map && map.has(serviceName)) {
+      this._node.destroyService(this._services.get(serviceName));
+      map.delete(serviceName);
+      debug(`Service is destroyed, and the service name is ${serviceName}.`);
+    }
   }
 
-  shutdown() {
-    rclnodejs.shutdown(this._node);
-    this._node = undefined;
-    this._publishers.clear();
-    this._subscriptions.clear();
-    this._clients.clear();
-    this._services.clear();
+  cleanResourceByBridgeId(bridgeId) {
+    if (this._clients.has(bridgeId)) {
+      this._clients.get(bridgeId).forEach(clientHandle => {
+        this._node.destroyClient(clientHandle.handle);
+        debug(`Client is destroyed for bridge ${bridgeId}.`);
+      });
+      this._clients.delete(bridgeId);
+    }
+
+    if (this._publishers.has(bridgeId)) {
+      this._publishers.get(bridgeId).forEach(publisherHandle => {
+        this._node.destroyPublisher(publisherHandle.handle);
+        debug(`Publisher is destroyed for bridge ${bridgeId}.`);
+      });
+      this._publishers.delete(bridgeId);
+    }
+
+    if (this._services.has(bridgeId)) {
+      this._services.get(bridgeId).forEach(service => {
+        this._node.destroyService(service);
+        debug(`Service is destroyed for bridge ${bridgeId}.`);
+      });
+      this._publishers.delete(bridgeId);
+    }
+
+    this._subscriptions.forEach(subscriptionHandle => {
+      if (subscriptionHandle.hasCallbackForId(bridgeId)) {
+        subscriptionHandle.removeCallback(bridgeId);
+        subscriptionHandle.release();
+        if (subscriptionHandle.count === 0) {
+          this._node.destroySubscription(subscriptionHandle.handle);
+          this._subscriptions.delete(subscriptionHandle.handle._topic);
+          debug(`Subscription is destroyed for bridge ${bridgeId}.`);
+        }
+      }
+    });
+
+    debug(`The bridge ${bridgeId} has been cleaned.`);
   }
 
   get node() {
     return this._node;
+  }
+
+  set node(node) {
+    this._node = node;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "ros2bridge",
-  "version": "0.0.1",
+  "name": "ros2-web-bridge",
+  "version": "0.1.0",
   "description": "Bridge the web clients to ROS2.0 by a JSON interface",
   "main": "index.js",
   "keywords": [
-    "rosbridge",
-    "ros2bridge",
     "ros2",
+    "webbridge",
+    "rcl",
     "rclnodejs"
   ],
   "bin": {
@@ -19,7 +19,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/RobotWebTools/rosbridge_suite.git"
+    "url": "git+https://github.com/RobotWebTools/ros2-web-bridge.git"
   },
   "authors": [
     "Minggang Wang <minggang.wang@intel.com>",
@@ -34,6 +34,7 @@
     "commander": "^2.12.2",
     "debug": "^3.1.0",
     "rclnodejs": "^0.x",
-    "ws": "^3.3.2"
+    "ws": "^3.3.2",
+    "uuid":"^3.1.0"
   }
 }


### PR DESCRIPTION
When a websocket connection is closed or has an error, the bridge should
release the rcl handles it has held.

This patch implements to register the events of the websocket
connection. So when error happens, we can destroy the resources and
close the connection correctly.