### PR TITLE
Send back the operation status to client

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -223,12 +223,13 @@ class Bridge extends EventEmitter {
       const op = this._opMap[command.op];
       if (op) {
         op.apply(this, [command]);
+        this._sendBackOperationStatus();
       }
     } catch (e) {
       debug(`Exception caught in Bridge.executeCommand(): ${e}`);
       e.id = command.id;
       e.op = command.op;
-      this._sendBackOperationError(e);
+      this._sendBackOperationStatus(e);
     }
   }
 
@@ -238,12 +239,15 @@ class Bridge extends EventEmitter {
     this._ws.send(JSON.stringify(response));
   }
 
-  _sendBackOperationError(error) {
+  _sendBackOperationStatus(error) {
+    let command;
     if (error) {
-      let command = {op: 'set_level', id: error.id, level: 'error'};
+      command = {op: 'set_level', id: error.id, level: 'error'};
       debug(`Error: ${error} happened when executing command ${error.op}`);
-      this._ws.send(JSON.stringify(command));
+    } else {
+      command = {op: 'set_level', level: 'none'};
     }
+    this._ws.send(JSON.stringify(command));
   }
 
   get ws() {


### PR DESCRIPTION
Currently, we only send back the status  when there is an error. Here we should
follow the protocol
https://github.com/RobotWebTools/rosbridge_suite/blob/develop/ROSBRIDGE_PROTOCOL.md

Whatever the result is, we will return the status of the operation. 'level' equals to
'error' when error happens, 'level' equals to 'none' when the execution is successful.

Fix #26