### PR TITLE
Return op set_level when request is not supported

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -223,6 +223,9 @@ class Bridge extends EventEmitter {
       if (op) {
         op.apply(this, [command]);
         this._sendBackOperationStatus();
+      } else {
+        debug(`Operation ${command.op} is not supported.`);
+        this._sendBackOperationStatus({id: command.id, op: command.op});
       }
     } catch (e) {
       debug(`Exception caught in Bridge.executeCommand(): ${e}`);


### PR DESCRIPTION
Currently when the bridge receives an operation code which is not supported,
it will be swallowed. This is not a good design.

After this patch, when meeting an unsupported operation, the bridge will
return an error to the client, which will notify the result.

Fix #34