### PR TITLE
Return error when the topic has already existed

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -74,6 +74,7 @@ class Bridge extends EventEmitter {
     this._resourceProvider = new ResourceProvider(node, this._bridgeId);
     this._registerConnectionEvent(ws);
     this._rebuildOpMap();
+    this._topicsPublished = new Map();
   }
 
   _registerConnectionEvent(ws) {
@@ -143,8 +144,15 @@ class Bridge extends EventEmitter {
 
   _rebuildOpMap() {
     this._registerOpMap('advertise', (command) => {
-      debug(`advertise a topic: ${command.topic}`);
-      this._resourceProvider.createPublisher(this._exractMessageType(command.type), command.topic);
+      let topic = command.topic;
+      if (this._topicsPublished.has(topic) && (this._topicsPublished.get(topic) !== command.type)) {
+        debug(`The topic ${topic} already exists with a different type ${this._topicsPublished.get(topic)}.`);
+        this._sendBackOperationStatus({id: command.id, op: command.op});
+        return;
+      }
+      debug(`advertise a topic: ${topic}`);
+      this._topicsPublished.set(topic, command.type);
+      this._resourceProvider.createPublisher(this._exractMessageType(command.type), topic);
     });
 
     this._registerOpMap('unadvertise', (command) => {


### PR DESCRIPTION
To align with the rosbridge v2 protocol spec:

- If the topic already exists with a different type, an error status message
  is sent and this message is dropped.

This patch implements this logic. Firstly it will check if the topic exists,
then check the type of it if there is already one. Finally, if the type is
different from the previous one and an error is returned.

Fix #36