### PR TITLE
Return warning when the unadvertised topic does not exist

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -99,6 +99,7 @@ class Bridge extends EventEmitter {
     if (!this._closed) {
       this._resourceProvider.clean();
       this._servicesResponse.clear();
+      this._topicsPublished.clear();
       this._closed = true;
     }
   }
@@ -147,8 +148,7 @@ class Bridge extends EventEmitter {
       let topic = command.topic;
       if (this._topicsPublished.has(topic) && (this._topicsPublished.get(topic) !== command.type)) {
         debug(`The topic ${topic} already exists with a different type ${this._topicsPublished.get(topic)}.`);
-        this._sendBackOperationStatus({id: command.id, op: command.op});
-        return;
+        throw new Error();
       }
       debug(`advertise a topic: ${topic}`);
       this._topicsPublished.set(topic, command.type);
@@ -156,7 +156,14 @@ class Bridge extends EventEmitter {
     });
 
     this._registerOpMap('unadvertise', (command) => {
+      if (!this._topicsPublished.has(command.topic)) {
+        debug(`The topic ${command.topic} does not exist.`);
+        let error = new Error();
+        error.level = 'warning';
+        throw error;
+      }
       debug(`unadvertise a topic: ${command.topic}`);
+      this._topicsPublished.delete(command.topic);
       this._resourceProvider.destroyPublisher(command.topic);
     });
 
@@ -252,7 +259,8 @@ class Bridge extends EventEmitter {
   _sendBackOperationStatus(error) {
     let command;
     if (error) {
-      command = {op: 'set_level', id: error.id, level: 'error'};
+      error.level = error.level || 'error';
+      command = {op: 'set_level', id: error.id, level: error.level};
       debug(`Error: ${error} happened when executing command ${error.op}`);
     } else {
       command = {op: 'set_level', level: 'none'};


### PR DESCRIPTION
To align with the rosbridge v2 protocol:

- If the topic does not exist, a warning status message is sent and this
  message is dropped.

This patch implements this logic.

Fix #37