### PR TITLE
Validate the topic when executing unadvertise

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -18,6 +18,7 @@ const ResourceProvider = require('./resource_provider.js');
 const debug = require('debug')('ros2-web-bridge:Bridge');
 const EventEmitter = require('events');
 const uuidv4 = require('uuid/v4');
+const {validator} = require('rclnodejs');
 
 class MessageParser {
   constructor() {
@@ -156,15 +157,22 @@ class Bridge extends EventEmitter {
     });
 
     this._registerOpMap('unadvertise', (command) => {
-      if (!this._topicsPublished.has(command.topic)) {
-        debug(`The topic ${command.topic} does not exist.`);
+      let topic = command.topic;
+      if (topic.startsWith('/')) {
+        validator.validateFullTopicName(topic);
+      } else {
+        validator.validateTopicName(topic);
+      }
+
+      if (!this._topicsPublished.has(topic)) {
+        debug(`The topic ${topic} does not exist.`);
         let error = new Error();
         error.level = 'warning';
         throw error;
       }
-      debug(`unadvertise a topic: ${command.topic}`);
-      this._topicsPublished.delete(command.topic);
-      this._resourceProvider.destroyPublisher(command.topic);
+      debug(`unadvertise a topic: ${topic}`);
+      this._topicsPublished.delete(topic);
+      this._resourceProvider.destroyPublisher(topic);
     });
 
     this._registerOpMap('publish', (command) => {


### PR DESCRIPTION
When the rosbridge is going to unadvertise a topic, the topic should be
validated first. If it is invalid, an error should be returned.

Fix #46