### PR TITLE
Close the socket server when exiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,12 @@ function createServer(options) {
   options.port = options.port || 9090;
   let server = new Server({port: options.port});
 
+  process.on('exit', () => {
+    debug('Application will exit.');
+    // Closing the server will trigger the individual connections to be closed and cleaned.
+    server.close();
+  });
+
   return rclnodejs.init().then(() => {
     let node = rclnodejs.createNode('ros2_web_bridge');
     let bridgeMap = new Map();

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -76,6 +76,7 @@ class Bridge extends EventEmitter {
     this._registerConnectionEvent(ws);
     this._rebuildOpMap();
     this._topicsPublished = new Map();
+    debug(`Web bridge ${this._bridgeId} is created`);
   }
 
   _registerConnectionEvent(ws) {
@@ -86,13 +87,13 @@ class Bridge extends EventEmitter {
     ws.on('close', () => {
       this.close();
       this.emit('close', this._bridgeId);
-      debug('Web socket connection closed');
+      debug(`Web bridge ${this._bridgeId} is closed`);
     });
 
     ws.on('error', (error) => {
       error.bridge = this;
       this.emit('error', error);
-      debug(`Web socket connection error: ${error}`);
+      debug(`Web socket of bridge ${this._bridgeId} error: ${error}`);
     });
   }
 


### PR DESCRIPTION
If the process of the module is going to exit, we should handle this event
and close all the websocket connections in order to cleanup the resoureces.

Fix #52