### PR TITLE
Corrent the wrong class member

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -165,11 +165,7 @@ class Bridge extends EventEmitter {
 
     this._registerOpMap('unadvertise', (command) => {
       let topic = command.topic;
-      if (topic.startsWith('/')) {
-        validator.validateFullTopicName(topic);
-      } else {
-        validator.validateTopicName(topic);
-      }
+      this._validateTopicOrService(command.topic);
 
       if (!this._topicsPublished.has(topic)) {
         debug(`The topic ${topic} does not exist.`);
@@ -243,7 +239,17 @@ class Bridge extends EventEmitter {
     });
 
     this._registerOpMap('unadvertise_service', (command) => {
-      this._nodeManager.destroyService(command.service, bridgeId);
+      let serviceName = command.service;
+      this._validateTopicOrService(serviceName);
+
+      if (!this._resourceProvider.hasService(serviceName)) {
+        debug(`The service ${serviceName} does not exist.`);
+        let error = new Error();
+        error.level = 'warning';
+        throw error;
+      }
+      debug(`unadvertise a service: ${serviceName}`);
+      this._resourceProvider.destroyService(command.service);
     });
   }
 
@@ -282,6 +288,14 @@ class Bridge extends EventEmitter {
     }
     debug('Response: ' + JSON.stringify(command));
     this._ws.send(JSON.stringify(command));
+  }
+
+  _validateTopicOrService(name) {
+    if (name.startsWith('/')) {
+      validator.validateFullTopicName(name);
+    } else {
+      validator.validateTopicName(name);
+    }
   }
 
   get ws() {

--- a/lib/resource_provider.js
+++ b/lib/resource_provider.js
@@ -116,6 +116,10 @@ class ResourceProvider {
     }
   }
 
+  hasService(serviceName) {
+    return this._services.has(serviceName);
+  }
+
   clean() {
     this._cleanHandleInMap(this._publishers);
     this._cleanHandleInMap(this._services);


### PR DESCRIPTION
As we use the ResourceProvider to manage the handles residing in ROS2,
the NodeManager has been abandoned which means we have to correct the API.

Fix #77