### PR TITLE
Support the format of message type for both ros1 and ros2

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -111,13 +111,19 @@ class Bridge extends EventEmitter {
   }
 
   _exractMessageType(type) {
-    const splitted = type.split('/');
-    return splitted[0] + '/msg/' + splitted[1];
+    if (type.indexOf('/msg/') === -1) {
+      const splitted = type.split('/');
+      return splitted[0] + '/msg/' + splitted[1];
+    }
+    return type;
   }
 
   _exractServiceType(type) {
-    const splitted = type.split('/');
-    return splitted[0] + '/srv/' + splitted[1];
+    if (type.indexOf('/srv/') === -1) {
+      const splitted = type.split('/');
+      return splitted[0] + '/srv/' + splitted[1];
+    }
+    return type;
   }
 
   _receiveMessage(message) {


### PR DESCRIPTION
Currently when creating a publisher, we will pass something like
"std_msgs/String" as the type of the message. But the type of the message
is defined as "std_msgs/msg/String" in ros2.

This patch support both of these two formates.

Fix #72