### PR TITLE
[UT] Add test cases for covering ROS1/ROS2 message type format

### DIFF
--- a/test/nodejs/protocol/test-advertise-service.js
+++ b/test/nodejs/protocol/test-advertise-service.js
@@ -51,7 +51,14 @@ module.exports = function() {
         op: 'advertise_service', type: 'example_interfaces/AddTwoInts', service: '/add_two_ints'},
       opCount: 1,
       finalStatus: 'none'
-    },    
+    },
+    {
+      title: 'advertise_service positive case 3: ROS2 interface type format',
+      advertiseServiceMsg: {
+        op: 'advertise_service', type: 'example_interfaces/srv/AddTwoInts', service: 'add_two_ints'},
+      opCount: 1,
+      finalStatus: 'none'
+    },
     {
       title: 'advertise_service negative case 1: unknown type',
       advertiseServiceMsg: {

--- a/test/nodejs/protocol/test-advertise.js
+++ b/test/nodejs/protocol/test-advertise.js
@@ -39,6 +39,13 @@ module.exports = function() {
       finalStatus: 'none'
     },
     {
+      title: 'advertise positive case 4: ROS2 message type format',
+      advertiseMsg1: {
+        op: 'advertise', id: 'advertise_ros2_msg', topic: 'advertise_ros2_msg_topic', type: 'std_msgs/msg/Byte'},
+      opCount: 1,
+      finalStatus: 'none'
+    },    
+    {
       title: 'advertise negative case 1',
       advertiseMsg1: {op: 'advertise', id: 'advertise_id5', topic: 'advertise_topic5', type: 'std_msgs/String'},
       advertiseMsg2: {op: 'advertise', id: 'advertise_id6', topic: 'advertise_topic5', type: 'std_msgs/Char'},

--- a/test/nodejs/protocol/test-publish.js
+++ b/test/nodejs/protocol/test-publish.js
@@ -34,6 +34,13 @@ module.exports = function() {
       finalStatus: 'none'
     },
     {
+      title: 'publish positive case 3: ROS2 message type format',
+      advertiseMsg: {op: 'advertise', topic: 'publish_ros2_msg_topic', type: 'std_msgs/msg/String'},
+      publishMsg: {op: 'publish', topic: 'publish_ros2_msg_topic', msg: {data: 'hello world!'}},
+      opCount: 2,
+      finalStatus: 'none'
+    },
+    {
       title: 'publish negative case 1: topic not exist',
       publishMsg: {op: 'publish', id: 'publish_id3', topic: 'publish_topic3', msg: {data: 'Hello World!'}},
       opCount: 1,

--- a/test/nodejs/protocol/test-unadvertise.js
+++ b/test/nodejs/protocol/test-unadvertise.js
@@ -34,6 +34,14 @@ module.exports = function() {
       finalStatus: 'none'
     },
     {
+      title: 'unadvertise positive case 3: ROS2 message type format',
+      advertiseMsg: {op: 'advertise', id: 'advertise_ros2_msg_setup', topic: 'unadvertise_ros2_msg_topic',
+        type: 'std_msgs/msg/String'},
+      unadvertiseMsg: {op: 'unadvertise', id: 'unadvertise_ros2_msg_setup', topic: 'unadvertise_ros2_msg_topic'},
+      opCount: 2,
+      finalStatus: 'none'
+    },
+    {
       title: 'unadvertise negative case 1',
       unadvertiseMsg: {op: 'unadvertise', id: 'unadvertise_id3', topic: 'unadvertise_topic3'},
       opCount: 1,


### PR DESCRIPTION
ros2-web-bridge now supports both ROS1 and ROS2 message/interfaces
type format, so add test cases to covering this feature. (+4)