### PR TITLE
Validate the name of the topic when it's being unsubscribed

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -196,7 +196,16 @@ class Bridge extends EventEmitter {
     });
 
     this._registerOpMap('unsubscribe', (command) => {
-      debug(`unsubscribe a topic named ${command.topic}`);
+      let topic = command.topic;
+      this._validateTopicOrService(topic);
+
+      if (!this._resourceProvider.hasSubscription(topic)) {
+        debug(`The topic ${topic} does not exist.`);
+        let error = new Error();
+        error.level = 'warning';
+        throw error;
+      }
+      debug(`unsubscribe a topic named ${topic}`);
       this._resourceProvider.destroySubscription(command.topic);
     });
 

--- a/lib/resource_provider.js
+++ b/lib/resource_provider.js
@@ -32,6 +32,10 @@ class ResourceProvider {
     return this._publishers.get(topicName).get();
   }
 
+  getSubscriptionByTopicName(topicName) {
+    return SubscriptionManager.getInstance().getSubscriptionByTopicName(topicName).get();
+  }
+
   getClientByServiceName(serviceName) {
     return this._clients.get(serviceName).get();
   }
@@ -118,6 +122,10 @@ class ResourceProvider {
 
   hasService(serviceName) {
     return this._services.has(serviceName);
+  }
+
+  hasSubscription(topicName) {
+    return SubscriptionManager.getInstance().getSubscriptionByTopicName(topicName) !== undefined;
   }
 
   clean() {

--- a/lib/subscription_manager.js
+++ b/lib/subscription_manager.js
@@ -47,7 +47,7 @@ class SubscriptionManager {
   }
 
   getSubscriptionByTopicName(topicName) {
-    return this._subscripions.get(topicName).get();
+    return this._subscripions.get(topicName);
   }
 
   createSubscription(messageType, topicName, bridgeId, callback) {
@@ -59,7 +59,7 @@ class SubscriptionManager {
           callback(topicName, message);
         });
       });
-      handle =  new HandleWithCallbacks(subscription, this._node.destroySubscription.bind(this._node));
+      handle = new HandleWithCallbacks(subscription, this._node.destroySubscription.bind(this._node));
       handle.addCallback(bridgeId, callback);
       this._subscripions.set(topicName, handle);
       debug(`Subscription has been created, and the topic name is ${topicName}.`);

--- a/test/nodejs/protocol/test-unsubscribe.js
+++ b/test/nodejs/protocol/test-unsubscribe.js
@@ -41,7 +41,7 @@ module.exports = function() {
       subscribeMsg1: {op: 'subscribe', id: 'subscribe_setup_id4', topic: 'unsubscribe_topic4', type: 'std_msgs/Byte'},
       unsubscribeMsg: {op: 'unsubscribe', id: 'subscribe_setup_id4', topic: 'unsubscribe_topic4x'},
       opCount: 2,
-      finalStatus: 'none'
+      finalStatus: 'warning'
     },
     {
       title: 'unsubscribe negative case 2: unknown id',


### PR DESCRIPTION
Before this patch, when the bridge received the operation code 'unsubscribe',
it will not validate the topic name(e.g. validity of the topic or if it existed).

This patch implements that when receiving the 'unsubscribe' op, the bridge will
valide the name of the topic first. If the name itself is invalid, an error will
return. If the topic name doesn't exist, a warning will return.

Fix #87