### PR TITLE
Disable the usage of TypedArray in rclnodejs

### DIFF
--- a/lib/resource_provider.js
+++ b/lib/resource_provider.js
@@ -64,7 +64,7 @@ class ResourceProvider {
   createClient(serviceType, serviceName) {
     let handle = this._clients.get(serviceName);
     if (!handle) {
-      handle = new RefCountingHandle(this._node.createClient(serviceType, serviceName),
+      handle = new RefCountingHandle(this._node.createClient(serviceType, serviceName, {enableTypedArray: false}),
         this._node.destroyClient.bind(this._node));
       this._clients.set(serviceName, handle);
       debug(`Client has been created, and the service name is ${serviceName}.`);
@@ -77,9 +77,10 @@ class ResourceProvider {
   createService(serviceType, serviceName, callback) {
     let handle = this._services.get(serviceName);
     if (!handle) {
-      handle = new RefCountingHandle(this._node.createService(serviceType, serviceName, (request, response) => {
-        callback(request, response);
-      }), this._node.destroyService.bind(this._node));
+      handle = new RefCountingHandle(this._node.createService(serviceType, serviceName, {enableTypedArray: false},
+        (request, response) => {
+          callback(request, response);
+        }), this._node.destroyService.bind(this._node));
       this._services.set(serviceName, handle);
       debug(`Service has been created, and the service name is ${serviceName}.`);
     } else {

--- a/lib/subscription_manager.js
+++ b/lib/subscription_manager.js
@@ -54,7 +54,7 @@ class SubscriptionManager {
     let handle = this._subscripions.get(topicName);
 
     if (!handle) {
-      let subscription = this._node.createSubscription(messageType, topicName, (message) => {
+      let subscription = this._node.createSubscription(messageType, topicName, {enableTypedArray: false}, (message) => {
         this._subscripions.get(topicName).callbacks.forEach(callback => {
           callback(topicName, message);
         });


### PR DESCRIPTION
Because the JSON does not have a representation of TypedArray, we disable it
explicitly when subscription/client/service are being created.

Fix #98