### PR TITLE
Add client connection mode using the unused --address CLI argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function createServer(options) {
     server = new WebSocket(options.address);
   } else {
     options.port = options.port || 9090;
-    debug('Starting server on port ' + options.port)
+    debug('Starting server on port ' + options.port);
     server = new WebSocket.Server({port: options.port});
   }
 
@@ -81,8 +81,8 @@ function createServer(options) {
 
     rclnodejs.spin(node);
     debug('The ros2-web-bridge has started.');
-    let ws_addr = (options.address) ? options.address : `ws://localhost:${options.port}`;
-    console.log(`Websocket started on ${ws_addr}`);
+    let wsAddr = (options.address) ? options.address : `ws://localhost:${options.port}`;
+    console.log(`Websocket started on ${wsAddr}`);
   }).catch(error => {
     debug(`Unknown error happened: ${error}, the module will be terminated.`);
     server.close();

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "wsserver": "node bin/rosbridge.js",
     "browser": "node test/browser/test-html.js",
     "lint": "eslint --max-warnings=0 index.js lib examples test",
-    "protocol": "mocha test/nodejs/protocol/entry.js",
+    "protocol": "mocha test/nodejs/protocol/entry.js test/nodejs/protocol/entry-client-mode.js",
     "ci": "npm run test && npm run protocol && npm run browser"
   },
   "license": "Apache-2.0",

--- a/test/nodejs/protocol/entry-client-mode.js
+++ b/test/nodejs/protocol/entry-client-mode.js
@@ -1,0 +1,77 @@
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const assert = require('assert');
+const child = require('child_process');
+const path = require('path');
+const WebSocket = require('ws');
+const TEST_PORT = 9091
+
+var rosbridge = path.resolve(__dirname, '../../../bin/rosbridge.js');
+
+describe('Rosbridge client mode', function() {
+  var server;
+  var bridgeClient;
+  this.timeout(5 * 1000);
+
+  function startBridge() {
+    bridgeClient = child.fork(rosbridge, 
+      ['--address=ws://localhost:'+TEST_PORT],
+      {silent: true},
+    );
+  }
+
+  after(function() {
+    if (bridgeClient) {
+      bridgeClient.kill();
+    }
+    server.close();
+  });
+
+  it('can connect to ws server and run command', function() {
+    return new Promise((resolve, reject) => {
+      server = new WebSocket.Server({port: TEST_PORT}, function() {
+        server.on('error', (err) => {
+          console.log(err);
+        });
+        server.on('connection', function(ws) {
+          let msg = {
+            op: 'publish',
+            id: 'publish:/example_topic:1',
+            topic: '/example_topic',
+            msg: {
+              data: 'hello from ros2bridge 0'
+            },
+            latch: false
+          };
+          ws.on('message', function(data) {
+            var response = JSON.parse(data);
+            assert.deepStrictEqual(response.level, 'error');
+            ws.close();
+            resolve();
+          });
+          // A long-standing race condition in WS handling of
+          // new connections prevents us from sending messages
+          // immediately after startup
+          // More details at https://github.com/websockets/ws/issues/1393
+          setTimeout(() => ws.send(JSON.stringify(msg)), 10);
+        });
+        startBridge();
+      });
+    });
+  });
+});
+

--- a/test/nodejs/protocol/entry-client-mode.js
+++ b/test/nodejs/protocol/entry-client-mode.js
@@ -18,7 +18,7 @@ const assert = require('assert');
 const child = require('child_process');
 const path = require('path');
 const WebSocket = require('ws');
-const TEST_PORT = 9091
+const TEST_PORT = 9091;
 
 var rosbridge = path.resolve(__dirname, '../../../bin/rosbridge.js');
 
@@ -30,7 +30,7 @@ describe('Rosbridge client mode', function() {
   function startBridge() {
     bridgeClient = child.fork(rosbridge, 
       ['--address=ws://localhost:'+TEST_PORT],
-      {silent: true},
+      {silent: true}
     );
   }
 


### PR DESCRIPTION
I have a setup with a internal (local) ROS network and an external (master) websocket server. The external server has a public websocket address, but the ROS network is not exposed. 

This PR allows the web bridge to be a websocket client that connects to the external server - requests can be issued by the server and proxied into the local network the same way a regular client would connect to the ros2-web-bridge as before. The `--address` arg was apparently totally unused, so I co-opted that to open a client connection instead of a server connection.

In the new test I added, there's a `setTimeout` I'm not particularly proud of. Without this timeout, the test would fail every 4-5 runs due to a race condition in the WS library - with the timeout, the test passes ~50x in a row. I tried other options including `process.nexttick` to no avail... I'm open to suggestions on a better way.