### PR TITLE
Add reconnection & backoff logic to client mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm install
 node bin/rosbridge.js
 ```
 
-If you want to start the server in a "client" mode (i.e. connecting the bridge to an existing websocket server, do this instead:
+If you want to start in client mode (i.e. connecting the bridge to an existing websocket server), do this instead:
 
 ```bash
 node bin/rosbridge.js --address ws://<address>:<port>

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -95,7 +95,6 @@ class Bridge extends EventEmitter {
     });
 
     ws.on('error', (error) => {
-      error.bridge = this;
       this.emit('error', error);
       debug(`Web socket of bridge ${this._bridgeId} error: ${error}`);
     });


### PR DESCRIPTION
* Adds randomized exponential backoff reconnection to server when running in client mode and the connection is closed
* Splits business logic of index.js into initial rclnodejs setup and websocket+bridge connection handling
* Fixes typo in README
* Moves "shutdown" behavior into a single function 
* Simplifies bridge error reporting (no longer requiring bridge ID to be passed, since we know by context which bridge we're listening to).