### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,19 +32,19 @@
     "Zhong Qiu <zhongx.qiu@intel.com>"
   ],
   "devDependencies": {
-    "async": "^2.6.0",
+    "async": "^3.2.0",
     "express": "^4.16.2",
-    "eslint": "^4.19.1",
-    "js-sha512": "^0.7.1",
-    "mocha": "^5.0.5",
-    "jsdom": "^11.5.1",
-    "puppeteer": "^1.2.0"
+    "eslint": "^6.8.0",
+    "js-sha512": "^0.8.0",
+    "mocha": "^7.1.1",
+    "jsdom": "^16.2.1",
+    "puppeteer": "^2.1.1"
   },
   "dependencies": {
-    "commander": "^4.1.0",
+    "commander": "^5.0.0",
     "debug": "^4.1.1",
-    "rclnodejs": "^0.11.1",
-    "uuid": "^3.1.0",
+    "rclnodejs": "^0.x.1",
+    "uuid": "^7.0.2",
     "ws": "^7.1.1"
   }
 }


### PR DESCRIPTION
This patch upgades:

- async 2.6.0 => 3.2.0
- elint 4.19.1 => 6.8.0
- js-sha512 0.7.1 =>0.8.0
- mocha 5.0.5 =>7.1.1
- jsdom 11.5.1 => 16.2.1
- puppeteer 1.2.0 => 2.1.1
- commander 4.1.0 => 5.0.0
- rclnodejs 0.11.1 => 0.13.0
- uuid 3.1.0 => 7.0.2

Fix #None