### PR TITLE
Use clearer error message when publishing without first advertising

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -189,6 +189,11 @@ class Bridge extends EventEmitter {
     this._registerOpMap('publish', (command) => {
       debug(`Publish a topic named ${command.topic} with ${JSON.stringify(command.msg)}`);
 
+      if (!this._topicsPublished.has(command.topic)) {
+        let error = new Error(`The topic ${command.topic} does not exist`);
+        error.level = 'error';
+        throw error;
+      }
       let publisher = this._resourceProvider.getPublisherByTopicName(command.topic);
       if (publisher) {
         publisher.publish(command.msg);


### PR DESCRIPTION
I'm new to ros2-web-bridge and its protocol, so it took me some time to understand that this is what happens when you try to publish without first advertising the topic and its type:

```sh
ros2-web-bridge:Bridge JSON command received: {"op":"publish","id":"publish:/example_topic2:1","topic":"/example_topic2","msg":{"data":"hello"},"latch":false} +11s
  ros2-web-bridge:Bridge Publish a topic named /example_topic2 with {"data":"hello"} +0ms
  ros2-web-bridge:Bridge Response: {"op":"status","level":"error","msg":"publish: TypeError: Cannot read property 'get' of undefined","id":"publish:/example_topic2:1"} +1ms
```

This PR adds a clearer error message (similar to what the other `op`s have):

```
  ros2-web-bridge:Bridge JSON command received: {"op":"publish","id":"publish:/example_topic2:1","topic":"/example_topic2","msg":{"data":"hello"},"latch":false} +2s
  ros2-web-bridge:Bridge Publish a topic named /example_topic2 with {"data":"hello"} +1ms
  ros2-web-bridge:Bridge Response: {"op":"status","level":"error","msg":"publish: Error: The topic /example_topic2 does not exist","id":"publish:/example_topic2:1"} +1ms
```