### PR TITLE
Ctrl+C rosbridge node from current commanding terminal

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,6 +135,8 @@ function createConnection(options) {
 
   let wsAddr = options.address || `ws://localhost:${options.port}`;
   console.log(`Websocket started on ${wsAddr}`);
+  // graceful shutdown rosbridge node commanding terminal
+  process.on('SIGINT', () => process.exit(1));
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ function createConnection(options) {
 
   let wsAddr = options.address || `ws://localhost:${options.port}`;
   console.log(`Websocket started on ${wsAddr}`);
-  // graceful shutdown rosbridge node commanding terminal
+  // gracefuly shutdown rosbridge node commanding terminal
   process.on('SIGINT', () => process.exit(1));
 }
 


### PR DESCRIPTION
enabled Ctrl+C terminate rosbridge node in commanding terminal (minor bug fix)